### PR TITLE
Fixing a typo in the container registry URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghrc.io/greut/eclint/cmd:v0.3.4
+FROM ghcr.io/greut/eclint/cmd:v0.3.4
 
 COPY entrypoint.sh /usr/local/bin/
 


### PR DESCRIPTION
Current container registry URL gives a error because of a typing error.
This PR fixes this.